### PR TITLE
DocuSign Native iOS SDK v2.1.4 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v2.1.4] - 07/22/2019
+
+### Changed
+* Improved Next Field Navigation -  The initial navigation moves to the next empty required field. New setup configuration. `DSM_SETUP_OFFLINE_SIGNING_NAVIGATE_BLANK_REQUIRED_FIELDS` to enable `Navigate blank required fields`.
+* Enhanced client logging - Verbose error logging for ‘login, persistence, & sync’ related methods.
+* Responsive signing is disabled for DocuSign SDK.
+
 ## [v2.1.3] - 05/17/2019
 
 ### Added

--- a/docusign-sdk-sample-swift/docusign-sdk-sample-swift.xcodeproj/project.pbxproj
+++ b/docusign-sdk-sample-swift/docusign-sdk-sample-swift.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 				C9FF31051F321A000076D6CA /* Resources */,
 				C9FF314E1F3258C50076D6CA /* Embed Frameworks */,
 				D7F5219825D2683BE85691CB /* [CP] Embed Pods Frameworks */,
-				B488346EF55C69F9CC0C784D /* [CP] Copy Pods Resources */,
+				07DDC5A0B3A3A2D85E993EBE /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -353,7 +353,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		B488346EF55C69F9CC0C784D /* [CP] Copy Pods Resources */ = {
+		07DDC5A0B3A3A2D85E993EBE /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/docusign-sdk-sample-swift/docusign-sdk-sample-swift/Controllers/LoginViewController.swift
+++ b/docusign-sdk-sample-swift/docusign-sdk-sample-swift/Controllers/LoginViewController.swift
@@ -36,8 +36,12 @@ class LoginViewController: UIViewController, UITextFieldDelegate
     {
         SVProgressHUD.show(withStatus: "Authenticating...");
         
-        let username = tf_username.text;
-        let password = tf_password.text;
+        guard let username = tf_username.text else {
+            return
+        }
+        guard let password = tf_password.text else {
+            return
+        }
         let integratorKey = ProfileManager.Static.integratorKey;
         let hostUrl: URL! = ProfileManager.Static.demoHostApi;
         


### PR DESCRIPTION
# DocuSign Native iOS SDK Changelog

## [v2.1.4] - 07/22/2019

### Changed
* Improved Next Field Navigation -  The initial navigation moves to the next empty required field. New setup configuration. `DSM_SETUP_OFFLINE_SIGNING_NAVIGATE_BLANK_REQUIRED_FIELDS` to enable `Navigate blank required fields`.
* Enhanced client logging - Verbose error logging for ‘login, persistence, & sync’ related methods.
* Responsive signing is disabled for DocuSign SDK.