### PR TITLE
v2.2.3: Offline Envelop: Save & Resume:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v2.2.3] - 02/11/2020
+
+### Added
+* Ability to save signing session of an offline envelop locally on a device and ability to resume signing progress for the saved envelope at a later time. `DSMEnvelopesManager` allows presenting an offline signing session with a previously saved envelope on same device using `+[DSMEnvelopesManager resumeSigningEnvelopeWithPresentingController:envelopeId:completion`.
+* New setup configuration `DSM_SETUP_ENABLE_OFFLINE_SIGNING_SAVE_ENVELOPE_PROGRESS_KEY` to enable the UI components to prompt users to save progress of an offline signed envelope to a device locally. If this configuration is enabled, by default it's disabled, `DSMEnvelopeCachedNotification` is sent whenever a local signer finishes signing session, this notification also contains the `envelopeId` that can be used later to resume signing progress of a saved envelope.
+* Additional notification `DSMOfflineEnvelopeSaveErrorNotification` is sent if an envelope fails to save on device with error under `DSM_ENVELOPE_SAVE_ERROR` domain. 
+* Resuming a fully signed envelope, which is ready for sync, is not allowed and it results in a new error under `DSM_ENVELOPE_RESUME_ERROR` domain. 
+
 ## [v2.2.2] - 01/30/2020
 
 ### Fixed

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '2.2.1'
+  s.version          = '2.2.3'
   s.summary          = 'DocuSign Native iOS Framework to sign and send in your iOS apps'
 
 # This description is used to generate tags and improve search results.
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'DocuSignSDK.framework'
   s.resource = 'DocuSignSDK.framework/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://github.com/docusign/native-ios-sdk/raw/release/2.2.1/DocuSignSDK.zip"}
+  s.source = { :http => "https://github.com/docusign/native-ios-sdk/raw/release/2.2.3/DocuSignSDK.zip"}
   s.source_files = 'DocuSignSDK.framework/Headers/*.h'
 
 end

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 Refer to [Getting Started Guide](https://guides.cocoapods.org/using/getting-started.html) to install CocoaPods via `gem install cocoapods` command and initialize the project. Take a look at sample projects included here [swift app](docusign-sdk-sample-swift/) and [objective-c app](docusign-sdk-sample-objc/).
 
 * Add `pod 'DocuSign'` to podfile to target(s) in your project. Example: [Swift Sample App Podfile](docusign-sdk-sample-swift/Podfile)
-* Run `pod install` in the same directory as your `Podfile` to get the DocuSign Native iOS SDK pod. This should result in `Installing DocuSign (2.2)` output on the console and corresponding changes in the `Podfile.lock`.
+* Run `pod install` in the same directory as your `Podfile` to get the DocuSign Native iOS SDK pod. This should result in `Installing DocuSign (2.2.3)` output on the console and corresponding changes in the `Podfile.lock`.
   * In case of an existing project that uses older version of 'DocuSign' pod, run `pod update 'DocuSign'` command on terminal to update 'DocuSign' pod to the latest version from a previous version.
 * Launch modified `.xcworkspace` project file with Xcode and use workspace going forward instead of `.xcodeproj` file.
 

--- a/Using-Envelope-Defaults.md
+++ b/Using-Envelope-Defaults.md
@@ -1,7 +1,5 @@
 # DocuSign Native iOS SDK - Using Envelope Defaults
 
-## Overview
-
 This guide explains how to use the Default Values for *Recipients*, *Tabs* and *Document Custom Fields* with a sample template. The swift sample code in sections below uses the values defined in the sample [template file](support-files/Home_insurance_claim_adjuster_template.json) and this can be uploaded to your account to get sample code to work with minimum modification. Do ensure that `templateId` matches the template uploaded in your sandbox.
 
 [`DSMEnvelopeDefault`](https://developers.docusign.com/ios_sdk/refdocs/html/interface_d_s_m_envelope_defaults.html) allows customizing the envelope during sign and send flow with a template. 
@@ -154,7 +152,7 @@ Tab default values are set using the `tabLabel` attribute for text based tab(s) 
 
 ## Document Custom Fields
 
-[Document Custom Fields](https://support.docusign.com/en/guides/ndse-admin-guide-custom-fields) are different than just [Custom Fields](https://support.docusign.com/guides/ndse-user-guide-custom-fields). This section of the guide deals with Document Custom Fields. `customFields` property on [`DSMEnvelopeDefault`](https://developers.docusign.com/ios_sdk/refdocs/html/interface_d_s_m_envelope_defaults.html) contains an object of [`DSMCustomField`](https://developers.docusign.com/ios_sdk/refdocs/html/interface_d_s_m_custom_fields.html) representing String or List baesd Document Custom Fields in the template. For Custom Field Tabs Refer to [Tab Default Values](#tab-default-values) for details on setting tab default value. 
+[Document Custom Fields](https://support.docusign.com/en/guides/ndse-admin-guide-custom-fields) are different than just [Custom Fields](https://support.docusign.com/guides/ndse-user-guide-custom-fields). This section of the guide deals with Document Custom Fields. `customFields` property on [`DSMEnvelopeDefault`](https://developers.docusign.com/ios_sdk/refdocs/html/interface_d_s_m_envelope_defaults.html) contains an object of [`DSMCustomField`](https://developers.docusign.com/ios_sdk/refdocs/html/interface_d_s_m_custom_fields.html) representing String or List based Document Custom Fields in the template. For Custom Field Tabs Refer to [Tab Default Values](#tab-default-values) for details on setting tab default value. 
 
 When an envelope is completed, Document Custom Fields are added to the [Certificate of Completion](https://support.docusign.com/en/guides/ndse-user-guide-history-coc).
 


### PR DESCRIPTION
* Ability to save signing session of an offline envelop locally on a device and ability to resume signing progress for the saved envelope at a later time. `DSMEnvelopesManager` allows presenting an offline signing session with a previously saved envelope on same device using `+[DSMEnvelopesManager resumeSigningEnvelopeWithPresentingController:envelopeId:completion`.
* New setup configuration `DSM_SETUP_ENABLE_OFFLINE_SIGNING_SAVE_ENVELOPE_PROGRESS_KEY` to enable the UI components to prompt users to save progress of an offline signed envelope to a device locally. If this configuration is enabled, by default it's disabled, `DSMEnvelopeCachedNotification` is sent whenever a local signer finishes signing session, this notification also contains the `envelopeId` that can be used later to resume signing progress of a saved envelope.
* Additional notification `DSMOfflineEnvelopeSaveErrorNotification` is sent if an envelope fails to save on device with error under `DSM_ENVELOPE_SAVE_ERROR` domain.
* Resuming a fully signed envelope, which is ready for sync, is not allowed and it results in a new error under `DSM_ENVELOPE_RESUME_ERROR` domain.