### PR TITLE
Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v3.0.3] - 02/08/2022
+### Added
+* Support to Paper signing through Fax flow with a new Signing Exit Notification reason `DSMSigningExitReasonFaxPending`
+
+### Fixed
+* Issue with Templates to disable templates with SBS recipients
+
 ## [v3.0.2] - 12/11/2022
 ### Fixed 
 * Fix Bug for Envelope resume after saving Issue 137( https://github.com/docusign/native-ios-sdk/issues/137)

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '3.0.2'
+  s.version          = '3.0.3'
   s.summary          = 'DocuSign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.0.2/DocuSignSDK.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.0.3/DocuSignSDK.zip"}
 end

--- a/DocuSignSDK.zip
+++ b/DocuSignSDK.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5b9ddcc16e722fb9d04e9a1c1e080fd3911e05b474c969cf0c318c54b8950ac
-size 176144334
+oid sha256:a5ad016feff07ca526d099fab46baf189c5c6fad11a72e9dbbf314384fb3bde4
+size 172272236


### PR DESCRIPTION
## [v3.0.3] - 02/08/2022
### Added
* Support to Paper signing through Fax flow with a new Signing Exit Notification reason `DSMSigningExitReasonFaxPending`

### Fixed
* Issue with Templates to disable templates with SBS recipients