### PR TITLE
Release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v3.0.4] - 03/24/2022
+### Added
+* Allow sending online envelopes with templates that have recipients with SBS (Standard Based Signature) by default.
+* New setup configuration `DSM_SETUP_DISABLE_STANDARD_BASED_SIGNATURE` to disable template sends that have SBS.
+
+### Fixed
+* Fix issue with Resuming envelopes created offline Issue #143
+
 ## [v3.0.3] - 02/08/2022
 ### Added
 * Support to Paper signing through Fax flow with a new Signing Exit Notification reason `DSMSigningExitReasonFaxPending`

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '3.0.3'
+  s.version          = '3.0.4'
   s.summary          = 'DocuSign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.0.3/DocuSignSDK.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.0.4/DocuSignSDK.zip"}
 end

--- a/DocuSignSDK.zip
+++ b/DocuSignSDK.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5ad016feff07ca526d099fab46baf189c5c6fad11a72e9dbbf314384fb3bde4
-size 172272236
+oid sha256:0c98457d613e9ff768f32c92c4930f3a5b64a5385ae5c406d4dfcea648d5b675
+size 171985895


### PR DESCRIPTION
## [v3.0.4] - 03/24/2022
### Added
* Allow sending online envelopes with templates that have recipients with SBS (Standard Based Signature) by default.
* New setup configuration `DSM_SETUP_DISABLE_STANDARD_BASED_SIGNATURE` to disable template sends that have SBS.

### Fixed
* Fix issue with Resuming envelopes created offline Issue [#143](https://github.com/docusign/native-ios-sdk/issues/143)