### PR TITLE
Updates for SDK Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * *(iOS 12+)* Support for OAuthLogin with helper functions for Authentication to DocuSign. If you use oAuth no need to create your own Authentication browser you can simply call `loginWithOAuthEnv` and pass the needed params to authenticate to DocuSignSDK.
 
 ### Changed
-* Added two new parameters to *Optional* params to `loginWithAccessToken` method for `refreshToken` and `expiresIn` in case of oAuth happening from Host App side.
+* Added two new parameters *Optional* to `loginWithAccessToken` method for `refreshToken` and `expiresIn` in case of oAuth happening from Host App side.
 * Prep work for spinning off DocuSignAPI as a separate Pod.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v3.1.0] - 06/14/2023
+### Added
+* *(iOS 12+)* Support for OAuthLogin with helper functions for Authentication to DocuSign. If you use oAuth no need to create your own Authentication browser you can simply call `loginWithOAuthEnv` and pass the needed params to authenticate to DocuSignSDK.
+
+### Changed
+* Added two new parameters to *Optional* params to `loginWithAccessToken` method for `refreshToken` and `expiresIn` in case of oAuth happening from Host App side.
+* Prep work for spinning off DocuSignAPI as a separate Pod.
+
+### Removed
+* Legacy Libraries (KeyChain)
+
 ## [v3.0.5] - 05/15/2023
 ### Added
 * [Conditional Tabs](https://developers.docusign.com/docs/esign-rest-api/esign101/concepts/tabs/conditional-fields/) are now supported for Templates and envelopes created locally (Envelopes downloaded from remote server are not supported yet)

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '3.0.5'
+  s.version          = '3.1.0'
   s.summary          = 'DocuSign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.0.5/DocuSignSDK.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.1.0/DocuSignSDK.zip"}
 end

--- a/DocuSignSDK.zip
+++ b/DocuSignSDK.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d23b7c979d0ca26e2619884d84b95ac5792e464b3ac1787cf55ba393659a821a
-size 172162884

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Additional information related to cocoapods is also avaiable with [swift app](do
 
 Use these steps to manually integrate the DocuSign framework in case your project doesn't use CocoaPods.
 
-* Download the [DocuSignSDK.zip](DocuSignSDK.zip) and unarchive it. 
+* Download the [DocuSignSDK.zip](https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.1.0/DocuSignSDK.zip) and unarchive it.
 * Copy the extracted folder to your project and add `DocuSignSDK.xcframework` and `DocuSignAPI.xcframework` to your dependencies. Also add `DocuSignSDK.bundle` to your project resources.
 
 Support


### PR DESCRIPTION
## [v3.1.0] - 06/14/2023
### Added
* *(iOS 12+)* Support for OAuthLogin with helper functions for Authentication to DocuSign. If you use oAuth no need to create your own Authentication browser you can simply call `loginWithOAuthEnv` and pass the needed params to authenticate to DocuSignSDK.

### Changed
* Added two new parameters *Optional* to `loginWithAccessToken` method for `refreshToken` and `expiresIn` in case of oAuth happening from Host App side.
* Prep work for spinning off DocuSignAPI as a separate Pod.

### Removed
* Legacy Libraries (KeyChain)