### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # DocuSign Native iOS SDK Changelog
 
-## [v3.2.0] - 01/18/2024
+## [v3.2.0] - 01/25/2024
 ### Added
 * Support for Sending online Templates with Signing Groups.
-* Support Xcode 17 Requirements for Signing Certification and Privacy Manifest.
+* Support Xcode 15 Requirements for Signing Certification and Privacy Manifest.
 * Support for Conditional Tabs for offline downloaded envelopes.
 * Added Configuration `DSM_SETUP_DISABLE_APPEARANCE` to Disable Applying Appearance changes Automatically on SDK setup [Issue #130](https://github.com/docusign/native-ios-sdk/issues/130)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v3.2.0] - 01/18/2024
+### Added
+* Support for Sending online Templates with Signing Groups.
+* Support Xcode 17 Requirements for Signing Certification and Privacy Manifest.
+* Support for Conditional Tabs for offline downloaded envelopes.
+* Added Configuration `DSM_SETUP_DISABLE_APPEARANCE` to Disable Applying Appearance changes Automatically on SDK setup [Issue #130](https://github.com/docusign/native-ios-sdk/issues/130)
+
+### Fixed
+* Fixes in Request layer and API calls setup.
+
 ## [v3.1.0] - 06/14/2023
 ### Added
 * *(iOS 12+)* Support for OAuthLogin with helper functions for Authentication to DocuSign. If you use oAuth no need to create your own Authentication browser you can simply call `loginWithOAuthEnv` and pass the needed params to authenticate to DocuSignSDK.

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '3.1.0'
+  s.version          = '3.2.0'
   s.summary          = 'DocuSign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.author           = { 'DocuSign' => 'devcenter@docusign.com' }
   s.social_media_url = 'https://twitter.com/DocuSignAPI'
 
-  s.platform = :ios, '10.0'
-  s.ios.deployment_target = '10.0'
+  s.platform = :ios, '12.0'
+  s.ios.deployment_target = '12.0'
   s.requires_arc = true
   s.preserve_paths = ['DocuSignSDK.xcframework', 'DocuSignAPI.xcframework']
   s.vendored_frameworks = [

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.1.0/DocuSignSDK.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.2.0/DocuSignSDK.zip"}
 end


### PR DESCRIPTION
## [v3.2.0] - 01/25/2024
### Added
* Support for Sending online Templates with Signing Groups.
* Support Xcode 17 Requirements for Signing Certification and Privacy Manifest.
* Support for Conditional Tabs for offline downloaded envelopes.
* Added Configuration `DSM_SETUP_DISABLE_APPEARANCE` to Disable Applying Appearance changes Automatically on SDK setup [Issue #130](https://github.com/docusign/native-ios-sdk/issues/130)

### Fixed
* Fixes in Request layer and API calls setup.