### PR TITLE
v3.4.0: Release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v3.4.0] - 09/20/2024
+
+### Fixed
+* Authorization issue that prevented some of the network calls to be successfully completed with DocusignAPI SDK.
+* Network calls with boolean parameters on DocusignAPI SDK interface now allows nil values as well. With earlier versions, these parameters were sent as either default true or false.
+* Optional Sign and Initial tabs show the dependent tabs correctly when used with conditional setup.
+
+### Changed
+* Templates with multichannel (SMS, Whatsapp) delivery recipients are currently blocked. Reach out to customer support or raise an issue on Github if you need this supported.
+* Outdated fonts replaced with modern assets.
+
 ## [v3.3.0] - 04/11/2024
 ### Changed
 * Branding update.

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.3.0/DocuSignSDK.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.4.0/DocuSignSDK.zip"}
 end

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '3.3.0'
+  s.version          = '3.4.0'
   s.summary          = 'Docusign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC


### PR DESCRIPTION
## [v3.4.0] - 09/20/2024

### Fixed
* Authorization issue that prevented some of the network calls to be successfully completed with DocusignAPI SDK.
* Network calls with boolean parameters on DocusignAPI SDK interface now allows nil values as well. With earlier versions, these parameters were sent as either default true or false.
* Optional Sign and Initial tabs show the dependent tabs correctly when used with conditional setup.

### Changed
* Templates with multichannel (SMS, Whatsapp) delivery recipients are currently blocked. Reach out to customer support or raise an issue on Github if you need this supported.
* Outdated fonts replaced with modern assets.
