### PR TITLE
Release 3.5.0 SPM and Xcode 16 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * Updated some DSAPI Models to combine common properties for Recipients and Tabs.
 * Updated Contacts fetch to retrieve Phone numbers in addition to email.
 
-
 ## [v3.4.0] - 09/20/2024
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # DocuSign Native iOS SDK Changelog
 
+## [v3.5.0] - 01/02/2025
+
+### Added
+* SPM Support - Use version 3.5.0 and refer to instructions on [SwiftPackageManager.md](https://github.com/docusign/native-ios-sdk/blob/master/SwiftPackageManager.md).
+* Xcode 16 support.
+
+### Changed
+* Updated some DSAPI Models to combine common properties for Recipients and Tabs.
+* Updated Contacts fetch to retrieve Phone numbers in addition to email.
+
+
 ## [v3.4.0] - 09/20/2024
 
 ### Fixed
@@ -62,7 +73,7 @@
 * Issue with Templates to disable templates with SBS recipients
 
 ## [v3.0.2] - 12/11/2022
-### Fixed 
+### Fixed
 * Fix Bug for Envelope resume after saving Issue 137( https://github.com/docusign/native-ios-sdk/issues/137)
 
 
@@ -82,11 +93,11 @@
 
 ## [v2.12] - 08/18/2022
 
-### Added 
-* New setup configuration key `DSM_SETUP_DISABLE_CUSTOMFIELD_DOCUSIGNIT` to control Custom tab `AppName=DocuSignIt` from being sent with all envelopes. The default of this config is `False`. Enabling it with `True` will only send this custom tab with Sign and Return envelopes. A Sign and Return envelope has a Signer (not a host or in-person-signer) with email that is the same as the Sender email. 
+### Added
+* New setup configuration key `DSM_SETUP_DISABLE_CUSTOMFIELD_DOCUSIGNIT` to control Custom tab `AppName=DocuSignIt` from being sent with all envelopes. The default of this config is `False`. Enabling it with `True` will only send this custom tab with Sign and Return envelopes. A Sign and Return envelope has a Signer (not a host or in-person-signer) with email that is the same as the Sender email.
 
-### Fixed 
-* Radio Buttons and tabs in general were not maintaining `value` attribute offline, now it can be used to identify tabs. 
+### Fixed
+* Radio Buttons and tabs in general were not maintaining `value` attribute offline, now it can be used to identify tabs.
 
 ## [v2.11] - 06/07/2022
 
@@ -112,7 +123,7 @@ _Now DocuSign XCFramework is built with Xcode13.3._
 * DocuSign Native iOS SDK supports Bitcode.
 
 ### Removed
-* Removed the `DSMAppearance` method to set navigation bar tint color separately `+ (void)setNavigationBarTintColor:(UIColor *)color;`. 
+* Removed the `DSMAppearance` method to set navigation bar tint color separately `+ (void)setNavigationBarTintColor:(UIColor *)color;`.
 
 ### Changed
 * Added `backgroundTintColor` and `fontSize` as additional parameters to set navigation bar text attributes with `DSMAppearance`. The updated method is `+ (void)setNavigationBarTitleTextColor:(UIColor *)textColor backgroundTintColor:(UIColor *)backgroundTintColor fontSize:(CGFloat)fontSize;`.
@@ -140,7 +151,7 @@ _Now DocuSign XCFramework is built with Xcode13.3._
 ## [v2.5.3] - 09/09/2021
 
 ### Added
-* New interface to launch captive signing using recipient view url with `presentCaptiveSigningWithPresentingController:signingUrl:envelopeId:recipientId:animated:completion:` in `DSMEnvelopesManager`. 
+* New interface to launch captive signing using recipient view url with `presentCaptiveSigningWithPresentingController:signingUrl:envelopeId:recipientId:animated:completion:` in `DSMEnvelopesManager`.
 * New interface to clear web cookies `clearAllWebCookies` on `DSMManager`.
 * New setup configuration `DSM_SETUP_CAPTIVE_SIGNING_DISABLE_LOCATION_PERMISSION` to disable location tracking during captive signing.
 
@@ -180,7 +191,7 @@ _Now DocuSign XCFramework is built with Xcode13.3._
 ## [v2.4] - 03/05/2021
 
 ### Added
-* New interface to create envelopes and start signing directly using [Compose Envelopes](Compose-Envelope.md) flow with `composeEnvelopeWithEnvelopeDefinition:signingMode:completion` in `DSMEnvelopesManager`. 
+* New interface to create envelopes and start signing directly using [Compose Envelopes](Compose-Envelope.md) flow with `composeEnvelopeWithEnvelopeDefinition:signingMode:completion` in `DSMEnvelopesManager`.
 
 ## [v2.3.8] - 01/22/2021
 
@@ -201,11 +212,11 @@ _Now DocuSign XCFramework is built with Xcode13.3._
 ## [v2.3.5] - 09/04/2020
 
 ### Added
-* Embedded (Captive) Signing is now supported with  `presentCaptiveSigningWithPresentingController` via `DSMEnvelopesManager`. API reference available at [Embedded Signing](https://developers.docusign.com/esign-rest-api/guides/concepts/embedding). 
+* Embedded (Captive) Signing is now supported with  `presentCaptiveSigningWithPresentingController` via `DSMEnvelopesManager`. API reference available at [Embedded Signing](https://developers.docusign.com/esign-rest-api/guides/concepts/embedding).
 * New setup configuration `DSM_SETUP_DISABLE_EMAIL_IPS_FIELD_CD` to allow client apps to hide the email field when the consumer disclosure screen is displayed.
 
 ### Fixed
-* Bug fixes and enhancements. 
+* Bug fixes and enhancements.
 
 ## [v2.3.4] - 07/17/2020
 
@@ -213,7 +224,7 @@ _Now DocuSign XCFramework is built with Xcode13.3._
 * Now `fontSize` property on the text tabs is used during offline signing. Tab level, `fontSize` ranges from `size7` to `size72`.  
 
 ### Fixed
-* Bug fixes and enhancements. 
+* Bug fixes and enhancements.
 
 ## [v2.3.3] - 07/08/2020
 
@@ -254,8 +265,8 @@ _Now DocuSign XCFramework is built with Xcode13.3._
 ### Added
 * Ability to save signing session of an offline envelop locally on a device and ability to resume signing progress for the saved envelope at a later time. `DSMEnvelopesManager` allows presenting an offline signing session with a previously saved envelope on same device using `+[DSMEnvelopesManager resumeSigningEnvelopeWithPresentingController:envelopeId:completion`.
 * New setup configuration `DSM_SETUP_ENABLE_OFFLINE_SIGNING_SAVE_ENVELOPE_PROGRESS_KEY` to enable the UI components to prompt users to save progress of an offline signed envelope to a device locally. If this configuration is enabled, by default it's disabled, `DSMEnvelopeCachedNotification` is sent whenever a local signer finishes signing session, this notification also contains the `envelopeId` that can be used later to resume signing progress of a saved envelope.
-* Additional notification `DSMOfflineEnvelopeSaveErrorNotification` is sent if an envelope fails to save on device with error under `DSM_ENVELOPE_SAVE_ERROR` domain. 
-* Resuming a fully signed envelope, which is ready for sync, is not allowed and it results in a new error under `DSM_ENVELOPE_RESUME_ERROR` domain. 
+* Additional notification `DSMOfflineEnvelopeSaveErrorNotification` is sent if an envelope fails to save on device with error under `DSM_ENVELOPE_SAVE_ERROR` domain.
+* Resuming a fully signed envelope, which is ready for sync, is not allowed and it results in a new error under `DSM_ENVELOPE_RESUME_ERROR` domain.
 
 ## [v2.2.2] - 01/30/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DocuSign Native iOS SDK Changelog
 
-## [v3.5.0] - 01/02/2025
+## [v3.5.0] - 01/06/2025
 
 ### Added
 * SPM Support - Use version 3.5.0 and refer to instructions on [SwiftPackageManager.md](https://github.com/docusign/native-ios-sdk/blob/master/SwiftPackageManager.md).

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '3.4.0'
+  s.version          = '3.5.0'
   s.summary          = 'Docusign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.4.0/DocuSignSDK.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignCombined.zip"}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .binaryTarget(name: "DocuSignSDK", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignSDK.zip", checksum: "24e7dfb257b36986ff016333d68d9ad9387415f2623367522f55f87e8e188884"),
-        .binaryTarget(name: "DocuSignAPI", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignAPI.zip", checksum: "894699791e49b43de165aac62874e27f2467392dcb210ef26c8a78191b8a7534"),
+        .binaryTarget(name: "DocuSignSDK", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignSDK.zip", checksum: "200a4c1245afe669ca04913e8d8c3494a64e9e9445302067d74fe9fb44a8a2eb"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignAPI.zip", checksum: "e95bf8f205de1f6e68169207a995a29fd3e57c96a16daccd0de93558e19047cb"),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/3.5.0/DocuSignSDK.zip", checksum: "24e7dfb257b36986ff016333d68d9ad9387415f2623367522f55f87e8e188884"),
-        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/3.5.0/DocuSignAPI.zip", checksum: "894699791e49b43de165aac62874e27f2467392dcb210ef26c8a78191b8a7534"),
+        .binaryTarget(name: "DocuSignSDK", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignSDK.zip", checksum: "24e7dfb257b36986ff016333d68d9ad9387415f2623367522f55f87e8e188884"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.5.0/DocuSignAPI.zip", checksum: "894699791e49b43de165aac62874e27f2467392dcb210ef26c8a78191b8a7534"),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Docusign",
+    products: [
+        .library(name: "DocuSignSDK", targets: ["DocuSignSDK"]),
+        .library(name: "DocuSignAPI", targets: ["DocuSignAPI"]),
+        ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/3.5.0/DocuSignSDK.zip", checksum: "24e7dfb257b36986ff016333d68d9ad9387415f2623367522f55f87e8e188884"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/3.5.0/DocuSignAPI.zip", checksum: "894699791e49b43de165aac62874e27f2467392dcb210ef26c8a78191b8a7534"),
+        ]
+)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
-![DocuSign Logo](images/docusign.svg)
-# DocuSign Native iOS SDK
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/3efff3ff-4efb-47d2-950d-881212b9f27e"  alt="Docusign Logo"/>
+</p>
 
-The DocuSign Native iOS SDK is a framework for Objective-C and Swift projects. Using the SDK, you can integrate DocuSign's online and offline signing features into your iOS application. Leverage native iOS UI components to integrate with the DocuSign ecosystem and use various features in your app.
+# Docusign Native iOS SDK
 
-Please refer to the [official site](https://developers.docusign.com/docs/mobile-sdks/ios-sdk/) for detailed instructions and getting started with DocuSign Sandbox.
+The Docusign Native iOS SDK is a framework for Objective-C and Swift projects. Using the SDK, you can integrate Docusign's online and offline signing features into your iOS application. Leverage native iOS UI components to integrate with the Docusign ecosystem and use various features in your app.
+
+Please refer to the [official site](https://developers.docusign.com/docs/mobile-sdks/ios-sdk/) for detailed instructions and getting started with Docusign Sandbox.
 
 Requirements
 ============
-- The SDK is written in Objective-C but will work with projects in Objective-C or Swift (5 and later).
 - Requires iOS 13 or later.
 - It is recommended that developers use Xcode 12.0 or later.
 
 Installation
 =============
 
-**CocoaPods** is the recommended way to integrate DocuSign Native iOS SDK. 
+**SPM**
+
+Instructions for [Swift Package Manager](https://www.swift.org/documentation/package-manager/) support can be found in the S[wiftPackageManager.md](https://github.com/docusign/native-ios-sdk/blob/feature/spm-support/SwiftPackageManager.md) Markdown file.
 
 **CocoaPods**
 
 Refer to [Getting Started Guide](https://guides.cocoapods.org/using/getting-started.html) to install CocoaPods via `gem install cocoapods` command and initialize the project. 
 
 * Add `pod 'DocuSign'` to podfile to target(s) in your project. Example: [Swift Sample App Podfile](docusign-sdk-sample-swift/Podfile)
-* Run `pod install` in the same directory as your `Podfile` to get the DocuSign Native iOS SDK pod. This should result in `Installing DocuSign (2.2.5)` output on the console and corresponding changes in the `Podfile.lock`.
+* Run `pod install` in the same directory as your `Podfile` to get the Docusign Native iOS SDK pod. This should result in `Installing DocuSign `[Latest Release](https://github.com/docusign/native-ios-sdk/releases) output on the console and corresponding changes in the `Podfile.lock`.
   * In case of an existing project that uses an older version of 'DocuSign' pod, run `pod update 'DocuSign'` command on the terminal to update 'DocuSign' pod to the latest version from a previous version.
 * Launch modified `.xcworkspace` project file with Xcode and use workspace going forward instead of `.xcodeproj` file.
   * Refer to [Integration Troubleshooting](support-files/Integration-Troubleshooting.md) in case of any issues.
@@ -32,14 +36,14 @@ Additional information related to cocoapods is also avaiable with [swift app](do
 
 Use these steps to manually integrate the DocuSign framework in case your project doesn't use CocoaPods.
 
-* Download the [DocuSignSDK.zip](https://docucdn-a.akamaihd.net/prod/docusigniossdk/3.1.0/DocuSignSDK.zip) and unarchive it.
-* Copy the extracted folder to your project and add `DocuSignSDK.xcframework` and `DocuSignAPI.xcframework` to your dependencies. Also add `DocuSignSDK.bundle` to your project resources.
-
+* Download the DocuSignSDKCombined.zip from the path [here](https://github.com/docusign/native-ios-sdk/blob/feature/spm-support/DocuSign.podspec#L32) and unarchive it.
+* Copy the extracted folder to your project and add `DocuSignSDK.xcframework` and `DocuSignAPI.xcframework` to your dependencies.
+  
 Support
 ===========
 
-* Refer the [Getting Started](https://developers.docusign.com/ios_sdk/developer.html) and [Integration](https://developers.docusign.com/ios_sdk/developer.html) section on the **Developer's Site** for more details on creating DocuSign Sandbox Account, Integration and using SDK Core Interfaces.
-* [Reference Docs](https://developers.docusign.com/ios_sdk/refdocs/html/annotated.html) to browse the latest developer documentation including API reference and public header files.
+* Refer the [Getting Started](https://developers.docusign.com/ios_sdk/developer.html) and [Integration](https://developers.docusign.com/ios_sdk/developer.html) section on the **Developer's Site** for more details on creating Docusign Sandbox Account, Integration and using SDK Core Interfaces.
+* [Reference Docs](https://docusign.github.io/native-ios-sdk/documentation/docusignsdk/) to browse the latest developer documentation including API reference and public header files.
 * Review [Change Log](CHANGELOG.md)
 
 Guides: 
@@ -52,15 +56,17 @@ Guides:
 
 Sample apps: 
  * For SDK version `2.6.0` and above refer our latest: [TGK Financial Sample App](https://github.com/docusign/sample-app-tgk-financial-ios/)
+[Deprecated] Sample Apps for reference with different languages
  * [swift](docusign-sdk-sample-swift/): Templates, Offline Envelopes, Events
  * [objective-c](docusign-sdk-sample-objc/): Templates, Offline Envelopes, Events
  * [swiftUI](docusign-sdk-sample-swiftui/): Captive (Embedded) Signing
 
 Reaching out: 
 * Open an [issue](https://github.com/docusign/native-ios-sdk/issues).
-* DocuSign also have an active developer community on Stack Overflow, search the [DocuSignAPI](http://stackoverflow.com/questions/tagged/docusignapi) tag.
+* 
+* Docusign also have an active developer community on Stack Overflow, search the [DocuSignAPI](http://stackoverflow.com/questions/tagged/docusignapi) tag.
 
 License
 =======
 
-The DocuSign Native iOS SDK is licensed under the following [License](LICENSE.docx).
+The Docusign Native iOS SDK is licensed under the following [License](LICENSE.docx).

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -4,7 +4,7 @@
 
 ### Using Xcode
 
-1. **Open your project** in Xcode.
+1. **Open your project** in Xcode 16.x.
 2. Navigate to **File** → **Add Package Dependency**.
 3. In the dialog that appears, enter the following **Docusign GitHub repository URL** for this library: `https://github.com/docusign/native-ios-sdk.git`
 4. Xcode will automatically fetch the repository and prompt you to select the version <= `3.5.0` you want to use.

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -1,0 +1,11 @@
+# Integrating with Docusign via Swift Package Manager (SPM)
+
+## Installation
+
+### Using Xcode
+
+1. **Open your project** in Xcode.
+2. Navigate to **File** → **Add Package Dependency**.
+3. In the dialog that appears, enter the following **Docusign GitHub repository URL** for this library: `https://github.com/docusign/native-ios-sdk.git`
+4. Xcode will automatically fetch the repository and prompt you to select the version <= `3.5.0` you want to use.
+5. After that, Xcode will integrate the package into your project and you’ll be able to import the library.


### PR DESCRIPTION
## [v3.5.0] - 01/02/2025

### Added
* SPM Support - Use version 3.5.0 and refer to instructions on [SwiftPackageManager.md](https://github.com/docusign/native-ios-sdk/blob/master/SwiftPackageManager.md).
* Xcode 16 support.

### Changed
* Updated some DSAPI Models to combine common properties for Recipients and Tabs.
* Updated Contacts fetch to retrieve Phone numbers in addition to email.
