### PR TITLE
Release/4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## [v4.1.1] - 04/02/2026
 
+### Added
+* Sync Notifications have a network reachability info added with "networkReachability" key.
+
 ### Update
 * Update for issues/186: During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification. Fortified the logic around it and additional checks have been added.
 * DSMEnvelopesManager syncEnvelope(withId:) sends a specific envelope to sync with server and also bypass the max-sync attempt block to retry syncing a failing envelope.
-
-### Added
-* Sync Notifications have a network reachability info added with "networkReachability" key.
 
 ## [v4.1.0] - 01/08/2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v4.1.1] - 03/12/2026
 
 ### Fixed
-* Fix issues/186: During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification.
+* Fix [#186](https://github.com/docusign/native-ios-sdk/issues/186): During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification.
 
 ### Added
 * Sync Notifications have a network reachability info added with "networkReachability" key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # DocuSign Native iOS SDK Changelog
 
-## [v4.1.0] - 01/08/2025
+## [v4.1.1] - 03/12/2026
+
+### Fixed
+* Fix issues/186: During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification.
+
+### Added
+* Sync Notifications have a network reachability info added with "networkReachability" key.
+
+## [v4.1.0] - 01/08/2026
 
 ### Added
 * Now supports xcode26 and iOS26.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # DocuSign Native iOS SDK Changelog
 
-## [v4.1.1] - 03/12/2026
+## [v4.1.1] - 04/02/2026
 
-### Fixed
-* Fix [#186](https://github.com/docusign/native-ios-sdk/issues/186): During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification.
+### Update
+* Update for issues/186: During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification. Fortified the logic around it and additional checks have been added.
+* DSMEnvelopesManager syncEnvelope(withId:) sends a specific envelope to sync with server and also bypass the max-sync attempt block to retry syncing a failing envelope.
 
 ### Added
 * Sync Notifications have a network reachability info added with "networkReachability" key.

--- a/DocuSign.podspec
+++ b/DocuSign.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocuSign'
-  s.version          = '4.1.0'
+  s.version          = '4.1.1'
   s.summary          = 'Docusign Native iOS Framework to sign and send in your iOS apps'
 
   s.description      = <<-DESC
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
 		"DocuSignAPI.xcframework"]
   s.resource   = 'DocuSignSDK.xcframework/**/DocuSignSDK.bundle'
   # Update the source path for new release
-  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.0/DocuSignCombined.zip"}
+  s.source = { :http => "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignCombined.zip"}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         .library(name: "DocusignNative", targets: ["DocusignNative"]),
         ],
     targets: [
-        .binaryTarget(name: "DocuSignSDK", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.0/DocuSignSDK.zip", checksum: "ec50f7bde32eb3b6f180e2a4e85e3d58f0f064297ecb154094fe5988f74fb75c"),
-        .binaryTarget(name: "DocuSignAPI", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.0/DocuSignAPI.zip", checksum: "11e33262bb09e969f987884890dddfdfbecb8f1eddc35cbe10b5c03e52e841e5"),
-        .binaryTarget(name: "DocusignNative", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.0/DocusignNative.zip", checksum: "4ad60520154cc71bcc7bed73ac3bd6f125ccb3728569a40c3aeb388abe4186aa"),
+        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "8c5fa5c0ad84731f764e88acc0a4a7235f7890acfefe57908ea4a60a741fe54f"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "681beb85166fc567f80f715674c7f6920110f07860e30ccd1a1675e858e83209"),
+        .binaryTarget(name: "DocusignNative", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "378ca031faa256f39f82e7a8c398e698e06d76b5a8db6c57503842bea2a11526"),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         .library(name: "DocusignNative", targets: ["DocusignNative"]),
         ],
     targets: [
-        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "2180ce9772226e13c282046c3f005987eb1fc131c602e78380f82261d672e76a"),
-        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "39d3f61aef12ef8fa210518c743652f430b3ce00c8a23c9b29e56a4796677471"),
-        .binaryTarget(name: "DocusignNative", url: "https://docutest-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "af597074b5554921d90510c8dcbe01bf85641834a3d62fdae0ebe1103a5ac4f3"),
+        .binaryTarget(name: "DocuSignSDK", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "2180ce9772226e13c282046c3f005987eb1fc131c602e78380f82261d672e76a"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "39d3f61aef12ef8fa210518c743652f430b3ce00c8a23c9b29e56a4796677471"),
+        .binaryTarget(name: "DocusignNative", url: "https://docucdn-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "af597074b5554921d90510c8dcbe01bf85641834a3d62fdae0ebe1103a5ac4f3"),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         .library(name: "DocusignNative", targets: ["DocusignNative"]),
         ],
     targets: [
-        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "8c5fa5c0ad84731f764e88acc0a4a7235f7890acfefe57908ea4a60a741fe54f"),
-        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "681beb85166fc567f80f715674c7f6920110f07860e30ccd1a1675e858e83209"),
-        .binaryTarget(name: "DocusignNative", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "378ca031faa256f39f82e7a8c398e698e06d76b5a8db6c57503842bea2a11526"),
+        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "2180ce9772226e13c282046c3f005987eb1fc131c602e78380f82261d672e76a"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "39d3f61aef12ef8fa210518c743652f430b3ce00c8a23c9b29e56a4796677471"),
+        .binaryTarget(name: "DocusignNative", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "af597074b5554921d90510c8dcbe01bf85641834a3d62fdae0ebe1103a5ac4f3"),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         .library(name: "DocusignNative", targets: ["DocusignNative"]),
         ],
     targets: [
-        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "2180ce9772226e13c282046c3f005987eb1fc131c602e78380f82261d672e76a"),
-        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "39d3f61aef12ef8fa210518c743652f430b3ce00c8a23c9b29e56a4796677471"),
-        .binaryTarget(name: "DocusignNative", url: "https://docutest-a.akamaihd.net/test/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "af597074b5554921d90510c8dcbe01bf85641834a3d62fdae0ebe1103a5ac4f3"),
+        .binaryTarget(name: "DocuSignSDK", url: "https://docutest-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignSDK.zip", checksum: "2180ce9772226e13c282046c3f005987eb1fc131c602e78380f82261d672e76a"),
+        .binaryTarget(name: "DocuSignAPI", url: "https://docutest-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocuSignAPI.zip", checksum: "39d3f61aef12ef8fa210518c743652f430b3ce00c8a23c9b29e56a4796677471"),
+        .binaryTarget(name: "DocusignNative", url: "https://docutest-a.akamaihd.net/prod/docusigniossdk/4.1.1/DocusignNative.zip", checksum: "af597074b5554921d90510c8dcbe01bf85641834a3d62fdae0ebe1103a5ac4f3"),
         ]
 )


### PR DESCRIPTION
## [v4.1.1] - 04/02/2026

### Added
* Sync Notifications have a network reachability info added with "networkReachability" key.

### Update
* Update for issues/186: During low-quality network conditions, the sync routine ended up sending false-negative failed notification instead of succeeded notification. Fortified the logic around it and additional checks have been added.
* DSMEnvelopesManager syncEnvelope(withId:) sends a specific envelope to sync with server and also bypass the max-sync attempt block to retry syncing a failing envelope.